### PR TITLE
Add iPad Air M2 devices

### DIFF
--- a/dataset/ipads.json
+++ b/dataset/ipads.json
@@ -144,26 +144,26 @@
         "processorFamily": "",
         "readableName": "iPad Pro 12.9-inch (6th generation) (WiFi+Cellular)"
     },
-	"iPad14,8": {
-		"deviceType": "Tablet",
-		"processorFamily": "M2",
-		"readableName": "iPad Air 11 inch 6th Gen (WiFi)"
-	},
-	"iPad14,9": {
-		"deviceType": "Tablet",
-		"processorFamily": "M2",
-		"readableName": "iPad Air 11 inch 6th Gen (WiFi+Cellular)"
-	},
-	"iPad14,10": {
-		"deviceType": "Tablet",
-		"processorFamily": "M2",
-		"readableName": "iPad Air 13 inch 6th Gen (WiFi)"
-	},
-	"iPad14,11": {
-		"deviceType": "Tablet",
-		"processorFamily": "M2",
-		"readableName": "iPad Air 13 inch 6th Gen (WiFi+Cellular)"
-	},
+    "iPad14,8": {
+        "deviceType": "Tablet",
+        "processorFamily": "M2",
+        "readableName": "iPad Air 11 inch 6th Gen (WiFi)"
+    },
+    "iPad14,9": {
+        "deviceType": "Tablet",
+        "processorFamily": "M2",
+        "readableName": "iPad Air 11 inch 6th Gen (WiFi+Cellular)"
+    },
+    "iPad14,10": {
+        "deviceType": "Tablet",
+        "processorFamily": "M2",
+        "readableName": "iPad Air 13 inch 6th Gen (WiFi)"
+    },
+    "iPad14,11": {
+        "deviceType": "Tablet",
+        "processorFamily": "M2",
+        "readableName": "iPad Air 13 inch 6th Gen (WiFi+Cellular)"
+    },
     "iPad2,1": {
         "deviceType": "Tablet",
         "processorFamily": "A5",

--- a/dataset/ipads.json
+++ b/dataset/ipads.json
@@ -144,6 +144,26 @@
         "processorFamily": "",
         "readableName": "iPad Pro 12.9-inch (6th generation) (WiFi+Cellular)"
     },
+	"iPad14,8": {
+		"deviceType": "Tablet",
+		"processorFamily": "M2",
+		"readableName": "iPad Air 11 inch 6th Gen (WiFi)"
+	},
+	"iPad14,9": {
+		"deviceType": "Tablet",
+		"processorFamily": "M2",
+		"readableName": "iPad Air 11 inch 6th Gen (WiFi+Cellular)"
+	},
+	"iPad14,10": {
+		"deviceType": "Tablet",
+		"processorFamily": "M2",
+		"readableName": "iPad Air 13 inch 6th Gen (WiFi)"
+	},
+	"iPad14,11": {
+		"deviceType": "Tablet",
+		"processorFamily": "M2",
+		"readableName": "iPad Air 13 inch 6th Gen (WiFi+Cellular)"
+	},
     "iPad2,1": {
         "deviceType": "Tablet",
         "processorFamily": "A5",


### PR DESCRIPTION
This PR adds 4 new device types:
- iPad Air 11 Wifi
- iPad Air 11 Cellular
- iPad Air 13 Wifi
- iPad Air 13 Cellular

Source for names: https://gist.github.com/adamawolf/3048717