### PR TITLE
Adding devices reported by Julian + new devices by Apple + Vision Pro

### DIFF
--- a/dataset/ipads.json
+++ b/dataset/ipads.json
@@ -194,6 +194,16 @@
         "processorFamily": "A16",
         "readableName": "iPad (11th generation) (WiFi+Cellular)"
     },
+    "iPad16,1": {
+        "deviceType": "Tablet",
+        "processorFamily": "A17 Pro",
+        "readableName": "iPad mini (7th generation) (WiFi)"
+    },
+    "iPad16,2": {
+        "deviceType": "Tablet",
+        "processorFamily": "A17 Pro",
+        "readableName": "iPad mini (7th generation) (WiFi+Cellular)"
+    },
     "iPad16,3": {
         "deviceType": "Tablet",
         "processorFamily": "M4",
@@ -213,6 +223,26 @@
         "deviceType": "Tablet",
         "processorFamily": "M4",
         "readableName": "iPad Pro 13-inch (5th generation) (WiFi+Cellular)"
+    },
+    "iPad17,1": {
+        "deviceType": "Tablet",
+        "processorFamily": "M5",
+        "readableName": "iPad Pro 11-inch (8th generation) (WiFi)"
+    },
+    "iPad17,2": {
+        "deviceType": "Tablet",
+        "processorFamily": "M5",
+        "readableName": "iPad Pro 11-inch (8th generation) (WiFi+Cellular)"
+    },
+    "iPad17,3": {
+        "deviceType": "Tablet",
+        "processorFamily": "M5",
+        "readableName": "iPad Pro 13-inch (8th generation) (WiFi)"
+    },
+    "iPad17,4": {
+        "deviceType": "Tablet",
+        "processorFamily": "M5",
+        "readableName": "iPad Pro 13-inch (8th generation) (WiFi+Cellular)"
     },
     "iPad2,1": {
         "deviceType": "Tablet",

--- a/dataset/ipads.json
+++ b/dataset/ipads.json
@@ -122,24 +122,9 @@
     "iPad14,10": {
         "deviceType": "Tablet",
         "processorFamily": "M2",
-        "readableName": "iPad Air 13-inch (6th generation) (WiFi+Cellular)"
-    },
-    "iPad14,11": {
-        "deviceType": "Tablet",
-        "processorFamily": "M2",
-        "readableName": "iPad Air 11-inch (6th generation) (WiFi)"
-    },
-    "iPad14,12": {
-        "deviceType": "Tablet",
-        "processorFamily": "M2",
-        "readableName": "iPad Air 11-inch (6th generation) (WiFi+Cellular)"
-    },
-    "iPad14,13": {
-        "deviceType": "Tablet",
-        "processorFamily": "M2",
         "readableName": "iPad Air 13-inch (6th generation) (WiFi)"
     },
-    "iPad14,14": {
+    "iPad14,11": {
         "deviceType": "Tablet",
         "processorFamily": "M2",
         "readableName": "iPad Air 13-inch (6th generation) (WiFi+Cellular)"
@@ -169,20 +154,45 @@
         "processorFamily": "M2",
         "readableName": "iPad Pro 12.9-inch (6th generation) (WiFi+Cellular)"
     },
-    "iPad14,7": {
+    "iPad14,8": {
         "deviceType": "Tablet",
         "processorFamily": "M2",
         "readableName": "iPad Air 11-inch (6th generation) (WiFi)"
     },
-    "iPad14,8": {
+    "iPad14,9": {
         "deviceType": "Tablet",
         "processorFamily": "M2",
         "readableName": "iPad Air 11-inch (6th generation) (WiFi+Cellular)"
     },
-    "iPad14,9": {
+    "iPad15,3": {
         "deviceType": "Tablet",
-        "processorFamily": "M2",
-        "readableName": "iPad Air 13-inch (6th generation) (WiFi)"
+        "processorFamily": "M3",
+        "readableName": "iPad Air 11-inch (7th generation) (WiFi)"
+    },
+    "iPad15,4": {
+        "deviceType": "Tablet",
+        "processorFamily": "M3",
+        "readableName": "iPad Air 11-inch (7th generation) (WiFi+Cellular)"
+    },
+    "iPad15,5": {
+        "deviceType": "Tablet",
+        "processorFamily": "M3",
+        "readableName": "iPad Air 13-inch (7th generation) (WiFi)"
+    },
+    "iPad15,6": {
+        "deviceType": "Tablet",
+        "processorFamily": "M3",
+        "readableName": "iPad Air 13-inch (7th generation) (WiFi+Cellular)"
+    },
+    "iPad15,7": {
+        "deviceType": "Tablet",
+        "processorFamily": "A16",
+        "readableName": "iPad (11th generation) (WiFi)"
+    },
+    "iPad15,8": {
+        "deviceType": "Tablet",
+        "processorFamily": "A16",
+        "readableName": "iPad (11th generation) (WiFi+Cellular)"
     },
     "iPad16,3": {
         "deviceType": "Tablet",

--- a/dataset/iphones.json
+++ b/dataset/iphones.json
@@ -184,6 +184,31 @@
         "processorFamily": "A18",
         "readableName": "iPhone 16 Plus"
     },
+    "iPhone17,5": {
+        "deviceType": "Phone",
+        "processorFamily": "A18",
+        "readableName": "iPhone 16e"
+    },
+    "iPhone18,1": {
+        "deviceType": "Phone",
+        "processorFamily": "A19 Pro",
+        "readableName": "iPhone 17 Pro"
+    },
+    "iPhone18,2": {
+        "deviceType": "Phone",
+        "processorFamily": "A19 Pro",
+        "readableName": "iPhone 17 Pro Max"
+    },
+    "iPhone18,3": {
+        "deviceType": "Phone",
+        "processorFamily": "A19",
+        "readableName": "iPhone 17"
+    },
+    "iPhone18,4": {
+        "deviceType": "Phone",
+        "processorFamily": "A19",
+        "readableName": "iPhone Air"
+    },
     "iPhone2,1": {
         "deviceType": "Phone",
         "processorFamily": "S5L8920",

--- a/dataset/macs.json
+++ b/dataset/macs.json
@@ -108,6 +108,20 @@
         "readableName": "MacBook Pro (16-inch, Nov 2023)",
         "systemFirstRelease": "12.2"
     },
+    "Mac15,12": {
+        "deviceType": "Laptop",
+        "processorFamily": "M3",
+        "processorType": "Apple Silicon",
+        "readableName": "MacBook Air (13-inch, M3, 2024)",
+        "systemFirstRelease": "14.4"
+    },
+    "Mac15,13": {
+        "deviceType": "Laptop",
+        "processorFamily": "M3",
+        "processorType": "Apple Silicon",
+        "readableName": "MacBook Air (15-inch, M3, 2024)",
+        "systemFirstRelease": "14.4"
+    },
     "Mac15,3": {
         "deviceType": "Laptop",
         "processorFamily": "M3",

--- a/dataset/macs.json
+++ b/dataset/macs.json
@@ -122,6 +122,13 @@
         "readableName": "MacBook Air (15-inch, M3, 2024)",
         "systemFirstRelease": "14.4"
     },
+    "Mac15,14": {
+        "deviceType": "Desktop",
+        "processorFamily": "M3 Ultra",
+        "processorType": "Apple Silicon",
+        "readableName": "Mac Studio (M3 Ultra, 2025)",
+        "systemFirstRelease": "15.3.1"
+    },
     "Mac15,3": {
         "deviceType": "Laptop",
         "processorFamily": "M3",
@@ -254,6 +261,13 @@
         "processorType": "Apple Silicon",
         "readableName": "Mac Studio (2025)",
         "systemFirstRelease": "15.0"
+    },
+    "Mac17,2": {
+        "deviceType": "Laptop",
+        "processorFamily": "M5",
+        "processorType": "Apple Silicon",
+        "readableName": "MacBook Pro (14-inch, M5, 2025)",
+        "systemFirstRelease": "15.1"
     },
     "MacBook10,1": {
         "deviceType": "Laptop",

--- a/dataset/other.json
+++ b/dataset/other.json
@@ -1,4 +1,14 @@
 {
+    "RealityDevice14,1": {
+        "deviceType": "Headset",
+        "processorFamily": "M2",
+        "readableName": "Apple Vision Pro (M2, 2024)"
+    },
+    "RealityDevice17,1": {
+        "deviceType": "Headset",
+        "processorFamily": "M5",
+        "readableName": "Apple Vision Pro (M5, 2025)"
+    },
     "iPod1,1": {
         "readableName": "iPod touch"
     },


### PR DESCRIPTION
This PR consists of 3 changes:

- Consolidated changes of https://github.com/TelemetryDeck/AppleModelNames/pull/6 & https://github.com/TelemetryDeck/AppleModelNames/pull/7
- New iPhones and M5 CPU devices introduced by Apple in September/October
- Apple Vision Pro was missing entirely, added the initial device (besides the updated M5 one)