### PR TITLE
Add current gen macs and iPads as of Jul 2026

### DIFF
--- a/dataset/ipads.json
+++ b/dataset/ipads.json
@@ -199,6 +199,16 @@
         "processorFamily": "A17 Pro",
         "readableName": "iPad mini (7th generation) (WiFi)"
     },
+    "iPad16,10": {
+        "deviceType": "Tablet",
+        "processorFamily": "M4",
+        "readableName": "iPad Air 13-inch (8th generation) (WiFi)"
+    },
+    "iPad16,11": {
+        "deviceType": "Tablet",
+        "processorFamily": "M4",
+        "readableName": "iPad Air 13-inch (8th generation) (WiFi+Cellular)"
+    },
     "iPad16,2": {
         "deviceType": "Tablet",
         "processorFamily": "A17 Pro",
@@ -233,16 +243,6 @@
         "deviceType": "Tablet",
         "processorFamily": "M4",
         "readableName": "iPad Air 11-inch (8th generation) (WiFi+Cellular)"
-    },
-    "iPad16,10": {
-        "deviceType": "Tablet",
-        "processorFamily": "M4",
-        "readableName": "iPad Air 13-inch (8th generation) (WiFi)"
-    },
-    "iPad16,11": {
-        "deviceType": "Tablet",
-        "processorFamily": "M4",
-        "readableName": "iPad Air 13-inch (8th generation) (WiFi+Cellular)"
     },
     "iPad17,1": {
         "deviceType": "Tablet",

--- a/dataset/ipads.json
+++ b/dataset/ipads.json
@@ -224,6 +224,26 @@
         "processorFamily": "M4",
         "readableName": "iPad Pro 13-inch (5th generation) (WiFi+Cellular)"
     },
+    "iPad16,8": {
+        "deviceType": "Tablet",
+        "processorFamily": "M4",
+        "readableName": "iPad Air 11-inch (8th generation) (WiFi)"
+    },
+    "iPad16,9": {
+        "deviceType": "Tablet",
+        "processorFamily": "M4",
+        "readableName": "iPad Air 11-inch (8th generation) (WiFi+Cellular)"
+    },
+    "iPad16,10": {
+        "deviceType": "Tablet",
+        "processorFamily": "M4",
+        "readableName": "iPad Air 13-inch (8th generation) (WiFi)"
+    },
+    "iPad16,11": {
+        "deviceType": "Tablet",
+        "processorFamily": "M4",
+        "readableName": "iPad Air 13-inch (8th generation) (WiFi+Cellular)"
+    },
     "iPad17,1": {
         "deviceType": "Tablet",
         "processorFamily": "M5",

--- a/dataset/macs.json
+++ b/dataset/macs.json
@@ -269,11 +269,53 @@
         "readableName": "MacBook Pro (14-inch, M5, 2025)",
         "systemFirstRelease": "15.1"
     },
+    "Mac17,3": {
+        "deviceType": "Laptop",
+        "processorFamily": "M5",
+        "processorType": "Apple Silicon",
+        "readableName": "MacBook Air (13-inch, M5, 2026)",
+        "systemFirstRelease": "26.3"
+    },
+    "Mac17,4": {
+        "deviceType": "Laptop",
+        "processorFamily": "M5",
+        "processorType": "Apple Silicon",
+        "readableName": "MacBook Air (15-inch, M5, 2026)",
+        "systemFirstRelease": "26.3"
+    },
     "Mac17,5": {
         "deviceType": "Laptop",
         "processorType": "A18 Pro",
         "readableName": "Apple MacBook Neo A18 Pro 6 CPU/5 GPU 13 inch",
         "systemFirstRelease": "26.3.0"
+    },
+    "Mac17,6": {
+        "deviceType": "Laptop",
+        "processorFamily": "M5 Pro",
+        "processorType": "Apple Silicon",
+        "readableName": "Apple MacBook Pro (16-inch, M5 Max, 2026)",
+        "systemFirstRelease": "26.3.1"
+    },
+    "Mac17,7": {
+        "deviceType": "Laptop",
+        "processorFamily": "M5 Max",
+        "processorType": "Apple Silicon",
+        "readableName": "Apple MacBook Pro (14-inch, M5 Max, 2026)",
+        "systemFirstRelease": "26.3.1"
+    },
+    "Mac17,8": {
+        "deviceType": "Laptop",
+        "processorFamily": "M5 Pro",
+        "processorType": "Apple Silicon",
+        "readableName": "Apple MacBook Pro (16-inch, M5 Pro, 2026)",
+        "systemFirstRelease": "26.3.1"
+    },
+    "Mac17,9": {
+        "deviceType": "Laptop",
+        "processorFamily": "M5 Pro",
+        "processorType": "Apple Silicon",
+        "readableName": "Apple MacBook Pro (14-inch, M5 Pro, 2026)",
+        "systemFirstRelease": "26.3.1"
     },
     "MacBook10,1": {
         "deviceType": "Laptop",


### PR DESCRIPTION
We've got some new Mac and iPad models popping up that aren't showing their pretty names, hoping this should fix that :)

If I've formatted anything incorrectly or gotten anything wrong, please drop a comment and I can fix it, or feel free to make any changes yourself.